### PR TITLE
Bump service version from 1.5.10 to 1.5.11

### DIFF
--- a/safe_notification_service/version.py
+++ b/safe_notification_service/version.py
@@ -1,2 +1,2 @@
-__version__ = '1.5.10'
+__version__ = '1.5.11'
 __version_info__ = tuple([int(num) if num.isdigit() else num for num in __version__.replace('-', '.', 1).split('.')])


### PR DESCRIPTION
Release: https://github.com/5afe/safe-notification-service/releases/tag/v1.5.11

⚠️ Unfortunately this commit didn't make it to the release (it should've been included)