### PR TITLE
Bump Django from 3.2.14 to 3.2.15

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==3.2.14
+Django==3.2.15
 celery==5.2.3
 cryptography==35.0.0
 django-authtools==1.7.0


### PR DESCRIPTION
Release notes: https://docs.djangoproject.com/en/4.0/releases/3.2.15/